### PR TITLE
Update DVSwitch-System-Builder.sh

### DIFF
--- a/DVSwitch-System-Builder.sh
+++ b/DVSwitch-System-Builder.sh
@@ -32,6 +32,7 @@ apt-get install quantar -y
 # apt-get install libstdc++-arm-none-eabi-newlib -y
 
 # Need to save the working directory. This will work for now
+mkdir /srv/DVSwitch-System-Builder
 cd /srv/DVSwitch-System-Builder
 
 cp -rf ./Directories/* /


### PR DESCRIPTION
script assumes that /srv/DVSwitch-System-Builder directory exists so I've added a live to create this directory as the script would fail at line 35.